### PR TITLE
add pwa debug toolbar

### DIFF
--- a/assets/controllers.json
+++ b/assets/controllers.json
@@ -17,6 +17,23 @@
                 "enabled": true,
                 "fetch": "lazy"
             }
+        },
+        "@survos/pwa-extra-bundle": {
+            "detector": {
+                "enabled": true,
+                "fetch": "lazy",
+                "autoimport": []
+            },
+            "toggle_online": {
+                "enabled": true,
+                "fetch": "lazy",
+                "autoimport": []
+            },
+            "install": {
+                "enabled": true,
+                "fetch": "lazy",
+                "autoimport": []
+            }
         }
     },
     "entrypoints": []

--- a/assets/controllers.json
+++ b/assets/controllers.json
@@ -12,6 +12,10 @@
             "sync-broadcast": {
                 "enabled": true,
                 "fetch": "lazy"
+            },
+            "prefetch-on-demand": {
+                "enabled": true,
+                "fetch": "lazy"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "phpdocumentor/reflection-docblock": "^5.3",
         "phpstan/phpdoc-parser": "^1.25",
         "spomky-labs/pwa-bundle": "1.1.x@dev",
+        "survos/pwa-extra-bundle": "^1.5",
         "symfony/asset": "7.0.*",
         "symfony/asset-mapper": "7.0.3",
         "symfony/clock": "7.0.*",

--- a/composer.lock
+++ b/composer.lock
@@ -1323,16 +1323,16 @@
         },
         {
             "name": "doctrine/persistence",
-            "version": "3.3.1",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/persistence.git",
-                "reference": "b6fd1f126b13c1f7e7321f7338b14a19116b5de4"
+                "reference": "477da35bd0255e032826f440b94b3e37f2d56f42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/persistence/zipball/b6fd1f126b13c1f7e7321f7338b14a19116b5de4",
-                "reference": "b6fd1f126b13c1f7e7321f7338b14a19116b5de4",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/477da35bd0255e032826f440b94b3e37f2d56f42",
+                "reference": "477da35bd0255e032826f440b94b3e37f2d56f42",
                 "shasum": ""
             },
             "require": {
@@ -1401,7 +1401,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/persistence/issues",
-                "source": "https://github.com/doctrine/persistence/tree/3.3.1"
+                "source": "https://github.com/doctrine/persistence/tree/3.3.2"
             },
             "funding": [
                 {
@@ -1417,7 +1417,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-01T19:53:13+00:00"
+            "time": "2024-03-12T14:54:36+00:00"
         },
         {
             "name": "doctrine/sql-formatter",
@@ -2236,12 +2236,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Spomky-Labs/pwa-bundle.git",
-                "reference": "d0515837fca769e4cad409b667d430f043950762"
+                "reference": "990500809ce7f1997ada204854787fb4fe7f8548"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Spomky-Labs/pwa-bundle/zipball/d0515837fca769e4cad409b667d430f043950762",
-                "reference": "d0515837fca769e4cad409b667d430f043950762",
+                "url": "https://api.github.com/repos/Spomky-Labs/pwa-bundle/zipball/990500809ce7f1997ada204854787fb4fe7f8548",
+                "reference": "990500809ce7f1997ada204854787fb4fe7f8548",
                 "shasum": ""
             },
             "require": {
@@ -2337,11 +2337,11 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2024-03-09T08:31:33+00:00"
+            "time": "2024-03-09T17:09:06+00:00"
         },
         {
             "name": "survos/core-bundle",
-            "version": "1.5.181",
+            "version": "1.5.183",
             "source": {
                 "type": "git",
                 "url": "https://github.com/survos/SurvosCoreBundle.git",
@@ -2417,7 +2417,7 @@
             ],
             "support": {
                 "issues": "https://github.com/survos/SurvosCoreBundle/issues",
-                "source": "https://github.com/survos/SurvosCoreBundle/tree/1.5.181"
+                "source": "https://github.com/survos/SurvosCoreBundle/tree/1.5.183"
             },
             "funding": [
                 {
@@ -2429,22 +2429,22 @@
         },
         {
             "name": "survos/pwa-extra-bundle",
-            "version": "1.5.181",
+            "version": "1.5.183",
             "source": {
                 "type": "git",
                 "url": "https://github.com/survos/SurvosPwaExtraBundle.git",
-                "reference": "ba3645f0bf4b109ea0dce8efa5e6ef66c8c0c3d7"
+                "reference": "f25ea23b33fc3c7e2d4e44f2ad929d53781e8781"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/survos/SurvosPwaExtraBundle/zipball/ba3645f0bf4b109ea0dce8efa5e6ef66c8c0c3d7",
-                "reference": "ba3645f0bf4b109ea0dce8efa5e6ef66c8c0c3d7",
+                "url": "https://api.github.com/repos/survos/SurvosPwaExtraBundle/zipball/f25ea23b33fc3c7e2d4e44f2ad929d53781e8781",
+                "reference": "f25ea23b33fc3c7e2d4e44f2ad929d53781e8781",
                 "shasum": ""
             },
             "require": {
                 "php": "^8.1",
                 "spomky-labs/pwa-bundle": "^1.1",
-                "survos/core-bundle": "^1.5.181",
+                "survos/core-bundle": "^1.5.183",
                 "symfony/asset-mapper": "^6.4 || ^7.0",
                 "symfony/config": "^6.4 || ^7.0",
                 "symfony/dependency-injection": "^6.4 || ^7.0",
@@ -2478,7 +2478,7 @@
             ],
             "support": {
                 "issues": "https://github.com/survos/SurvosPwaExtraBundle/issues",
-                "source": "https://github.com/survos/SurvosPwaExtraBundle/tree/1.5.181"
+                "source": "https://github.com/survos/SurvosPwaExtraBundle/tree/1.5.183"
             },
             "funding": [
                 {
@@ -2486,7 +2486,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-09T14:29:46+00:00"
+            "time": "2024-03-13T12:50:04+00:00"
         },
         {
             "name": "symfony/asset",
@@ -9464,6 +9464,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-09-28T06:45:17+00:00"
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f9ea243dbde2a7860af5a67556ffb50",
+    "content-hash": "27d8cbbcdd4abd53498d01f4ef27d83a",
     "packages": [
         {
             "name": "api-platform/core",
@@ -2338,6 +2338,155 @@
                 }
             ],
             "time": "2024-03-09T08:31:33+00:00"
+        },
+        {
+            "name": "survos/core-bundle",
+            "version": "1.5.181",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/survos/SurvosCoreBundle.git",
+                "reference": "9884289cb72169fe45d9aec5714c9a27a1849a24"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/survos/SurvosCoreBundle/zipball/9884289cb72169fe45d9aec5714c9a27a1849a24",
+                "reference": "9884289cb72169fe45d9aec5714c9a27a1849a24",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1",
+                "symfony/config": "^6.4 || ^7.0",
+                "symfony/dependency-injection": "^6.4 || ^7.0",
+                "symfony/http-kernel": "^6.4 || ^7.0",
+                "symfony/serializer": "^6.4 || ^7.0",
+                "symfony/string": "^6.4 || ^7.0",
+                "twig/twig": "^3.4"
+            },
+            "conflict": {
+                "survos/api-grid-bundle": "<1.2.57",
+                "survos/auth-bundle": "<1.2.57",
+                "survos/barcode-bundle": "<1.2.57",
+                "survos/bootstrap-bundle": "<1.2.57",
+                "survos/command-bundle": "<1.2.57",
+                "survos/crawler-bundle": "<1.2.57",
+                "survos/doc-bundle": "<1.2.57",
+                "survos/faker-bundle": "<1.2.57",
+                "survos/grid-bundle": "<1.2.57",
+                "survos/grid-group-bundle": "<1.2.57",
+                "survos/html-prettify-bundle": "<1.2.57",
+                "survos/import-bridge": "<1.2.57",
+                "survos/inspection-bundle": "<1.2.57",
+                "survos/location-bundle": "<1.2.57",
+                "survos/maker-bundle": "<1.2.57",
+                "survos/providence-bundle": "<1.2.57",
+                "survos/ruler-bundle": "<1.2.57",
+                "survos/stripe-product": "<1.2.57",
+                "survos/tree-bundle": "<1.2.57",
+                "survos/wiki-bundle": "<1.2.57",
+                "survos/workflow-helper-bundle": "<1.2.57"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.10",
+                "symfony/browser-kit": "^6.4 || ^7.0",
+                "symfony/framework-bundle": "^6.4 || ^7.0",
+                "symfony/phpunit-bridge": "^6.4 || ^7.0",
+                "symfony/twig-bundle": "^6.4 || ^7.0",
+                "symfony/var-dumper": "^6.4 || ^7.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.6-dev"
+                },
+                "symfony": {
+                    "require": "^6.4 || ^7.0"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Survos\\CoreBundle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Traits and Interfaces common to other Survos bundles",
+            "keywords": [
+                "symfony6"
+            ],
+            "support": {
+                "issues": "https://github.com/survos/SurvosCoreBundle/issues",
+                "source": "https://github.com/survos/SurvosCoreBundle/tree/1.5.181"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kbond",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-05T19:16:42+00:00"
+        },
+        {
+            "name": "survos/pwa-extra-bundle",
+            "version": "1.5.181",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/survos/SurvosPwaExtraBundle.git",
+                "reference": "ba3645f0bf4b109ea0dce8efa5e6ef66c8c0c3d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/survos/SurvosPwaExtraBundle/zipball/ba3645f0bf4b109ea0dce8efa5e6ef66c8c0c3d7",
+                "reference": "ba3645f0bf4b109ea0dce8efa5e6ef66c8c0c3d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1",
+                "spomky-labs/pwa-bundle": "^1.1",
+                "survos/core-bundle": "^1.5.181",
+                "symfony/asset-mapper": "^6.4 || ^7.0",
+                "symfony/config": "^6.4 || ^7.0",
+                "symfony/dependency-injection": "^6.4 || ^7.0",
+                "symfony/http-kernel": "^6.4 || ^7.0",
+                "twig/twig": "^3.4"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.10",
+                "symfony/browser-kit": "^6.4 || ^7.0",
+                "symfony/framework-bundle": "^6.4 || ^7.0",
+                "symfony/phpunit-bridge": "^6.4 || ^7.0",
+                "symfony/twig-bundle": "^6.4 || ^7.0",
+                "symfony/var-dumper": "^6.4 || ^7.0",
+                "zenstruck/console-extra": "^1.4"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Survos\\PwaExtraBundle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Extra tools for https://github.com/Spomky-Labs/phpwa",
+            "keywords": [
+                "pwa",
+                "symfony",
+                "symfony-ux"
+            ],
+            "support": {
+                "issues": "https://github.com/survos/SurvosPwaExtraBundle/issues",
+                "source": "https://github.com/survos/SurvosPwaExtraBundle/tree/1.5.181"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kbond",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-09T14:29:46+00:00"
         },
         {
             "name": "symfony/asset",
@@ -10108,5 +10257,5 @@
         "ext-imagick": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -2236,12 +2236,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Spomky-Labs/pwa-bundle.git",
-                "reference": "ad5cc0e84b8959b5c2312407a5576099efd30b55"
+                "reference": "d0515837fca769e4cad409b667d430f043950762"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Spomky-Labs/pwa-bundle/zipball/ad5cc0e84b8959b5c2312407a5576099efd30b55",
-                "reference": "ad5cc0e84b8959b5c2312407a5576099efd30b55",
+                "url": "https://api.github.com/repos/Spomky-Labs/pwa-bundle/zipball/d0515837fca769e4cad409b667d430f043950762",
+                "reference": "d0515837fca769e4cad409b667d430f043950762",
                 "shasum": ""
             },
             "require": {
@@ -2337,7 +2337,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2024-03-07T20:31:48+00:00"
+            "time": "2024-03-09T08:31:33+00:00"
         },
         {
             "name": "symfony/asset",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -17,4 +17,6 @@ return [
     Nelmio\CorsBundle\NelmioCorsBundle::class => ['all' => true],
     ApiPlatform\Symfony\Bundle\ApiPlatformBundle::class => ['all' => true],
     SpomkyLabs\PwaBundle\SpomkyLabsPwaBundle::class => ['all' => true],
+    Survos\CoreBundle\SurvosCoreBundle::class => ['all' => true],
+    Survos\PwaExtraBundle\SurvosPwaExtraBundle::class => ['all' => true],
 ];

--- a/config/packages/pwa.yaml
+++ b/config/packages/pwa.yaml
@@ -32,13 +32,24 @@ pwa:
         src: "sw.js"
         skip_waiting: true
         workbox:
-            page_cache:
-                strategy: 'staleWhileRevalidate'
-                broadcast: true
-                broadcast_headers:
-                    - 'X-App-Cache'
-                urls:
-                - 'app_homepage'
+            page_caches:
+                  - cache_name: page_cache
+                    regex: "/$"
+                    strategy: 'staleWhileRevalidate'
+                    broadcast: true
+                    broadcast_headers:
+                        - 'X-App-Cache'
+                    urls:
+                    - 'app_homepage'
+                  - cache_name: pages 
+                    regex: "/api"
+                    strategy: 'cacheFirst'
+                    broadcast: true
+                    broadcast_headers:
+                        - 'X-App-Cache'
+                    urls:
+                        - 'api_doc'
+                        - '_api_/items{._format}_get_collection' 
             offline_fallback:
                 page: 'app_homepage'
             background_sync:

--- a/config/packages/pwa.yaml
+++ b/config/packages/pwa.yaml
@@ -33,6 +33,10 @@ pwa:
         skip_waiting: true
         workbox:
             page_cache:
+                strategy: 'staleWhileRevalidate'
+                broadcast: true
+                broadcast_headers:
+                    - 'X-App-Cache'
                 urls:
                 - 'app_homepage'
             offline_fallback:

--- a/src/Controller/HomepageController.php
+++ b/src/Controller/HomepageController.php
@@ -21,10 +21,14 @@ class HomepageController extends AbstractController
     {
         $form = $this->itemHandler->prepare();
 
-        return $this->render('homepage/index.html.twig', [
+        $response = $this->render('homepage/index.html.twig', [
             'form' => $form,
             'items' => $this->itemRepository->findBy([], ['id' => 'DESC'], 50),
         ]);
+        //Used to test the Broacast system
+        $response->headers->set('X-App-Cache', random_int(0,5) === 0 ? 'foo' : 'bar');
+
+        return $response;
     }
 
     #[Route('/add', name: 'app_add_item', methods: [Request::METHOD_POST])]

--- a/symfony.lock
+++ b/symfony.lock
@@ -75,6 +75,12 @@
     "spomky-labs/pwa-bundle": {
         "version": "1.1.x-dev"
     },
+    "survos/core-bundle": {
+        "version": "1.5.181"
+    },
+    "survos/pwa-extra-bundle": {
+        "version": "1.5.181"
+    },
     "symfony/asset-mapper": {
         "version": "7.0",
         "recipe": {

--- a/templates/homepage/index.html.twig
+++ b/templates/homepage/index.html.twig
@@ -40,6 +40,20 @@
             installButton.classList.remove('hover:bg-gray-50', 'dark:hover:bg-gray-800');
             installButton.classList.add('text-white', 'bg-blue-400', 'dark:bg-blue-500', 'cursor-not-allowed', 'font-medium', 'rounded-lg', 'text-sm', 'px-5', 'py-2.5', 'text-center');
         }
+
+        navigator.serviceWorker.addEventListener('message', async event => {
+            if (event.data.meta === 'workbox-broadcast-update') {
+                const {cacheName, updatedURL} = event.data.payload;
+                if (updatedURL === window.location.href) {
+                    const toast = document.getElementById('toast-refresh');
+                    toast.classList.remove('hidden');
+                    setTimeout(() => {
+                        toast.classList.add('hidden');
+                    }, 5000);
+                }
+                console.log(`The cache ${cacheName} has been updated with ${updatedURL}`);
+            }
+        });
     </script>
 {% endblock %}
 {% block body %}
@@ -207,6 +221,25 @@
                     <div class="tooltip-arrow" data-popper-arrow></div>
                 </div>
             </div>
+        </div>
+    </div>
+
+
+    <div id="toast-refresh" class="hidden flex items-center w-full max-w-xs p-4 text-gray-500 bg-white rounded-lg shadow dark:text-gray-400 dark:bg-gray-800" role="alert">
+        <div class="text-sm font-normal">
+            An update exists.
+        </div>
+        {% set route = app.request.attributes.get('_route') %}
+        {% set route_params = app.request.attributes.get('_route_params') %}
+        {% set params = route_params|merge(app.request.query.all) %}
+        <div class="flex items-center ms-auto space-x-2 rtl:space-x-reverse">
+            <a class="text-sm font-medium text-blue-600 p-1.5 hover:bg-blue-100 rounded-lg dark:text-blue-500 dark:hover:bg-gray-700" href="{{ path(route, params) }}">Refresh</a>
+            <button type="button" class="ms-auto -mx-1.5 -my-1.5 bg-white text-gray-400 hover:text-gray-900 rounded-lg focus:ring-2 focus:ring-gray-300 p-1.5 hover:bg-gray-100 inline-flex items-center justify-center h-8 w-8 dark:text-gray-500 dark:hover:text-white dark:bg-gray-800 dark:hover:bg-gray-700" data-dismiss-target="#toast-undo" aria-label="Close">
+                <span class="sr-only">Close</span>
+                <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
+                    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"/>
+                </svg>
+            </button>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
my branch ('tac') diverged enough from the demo that I created a new branch from the most recent version of 'main', with just pwa-extra-bundle added.

It adds the debug toolbar.  Still needs some work, but it's been helpful to me.

To see the strategies in action, turn on Preserve Log in the Chrome Console tab.  The go to one of the url tabs, when you load  a URL you can see it in action.  Depending on the strategy, you should also be able to do all that offline.

![image](https://github.com/Spomky-Labs/phpwa-demo/assets/619585/6abc5305-5ebc-49ce-9be9-8477cdee7937)
